### PR TITLE
Fix errors by building Bootstrap CSS.

### DIFF
--- a/tasks/amdserialize.js
+++ b/tasks/amdserialize.js
@@ -44,8 +44,11 @@ module.exports = function (grunt) {
 			// Process images included in css with url() param.
 			if (/.css$/.test(filepath)) {
 				var fileDir = filepath.replace(/[^\/]*$/, "");
-				var urlRE = /url\(['"]?([^\)'"]*)/g;
+				var urlRE = /url\(['"]?([^\)'"\?#]*)/g;
 				var match = null;
+
+				grunt.file.mkdir(fileDir);
+
 				// Extra parenthesis in the while condition to silence jshint.
 				// The assignment is required here to access the matched groups of a global regexp.
 				while ((match = urlRE.exec(content))) {


### PR DESCRIPTION
Bootstrap has something like `url(‘/path/to/font#iefix’)` (some has query args, too.). Also make sure `fileDir` directory exists so that relative path reference in `url()` works.

Please let me know if a test case is needed here. Thanks. CC @clmath 
