### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
 	"bugs": {
 		"url": "https://github.com/ibm-js/grunt-amd-build/issues"
 	},
-	"licenses": [{
-		"type": "BSD",
-		"url": "https://github.com/ibm-js/grunt-amd-build/blob/master/LICENSE"
-	}],
+	"licenses": [
+		{
+			"type": "BSD",
+			"url": "https://github.com/ibm-js/grunt-amd-build/blob/master/LICENSE"
+		}
+	],
 	"main": "Gruntfile.js",
 	"engines": {
 		"node": ">= 0.8.0"
@@ -27,13 +29,15 @@
 		"promised-io": "0.3.x"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": ">=0.4.0"
 	},
 	"dependencies": {
 		"requirejs": "~2.1.9"
 	},
 	"keywords": [
-		"gruntplugin", "amd", "build"
+		"gruntplugin",
+		"amd",
+		"build"
 	],
 	"readmeFilename": "README.md"
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
